### PR TITLE
Add support for multisampled render textures

### DIFF
--- a/src/Layer.ts
+++ b/src/Layer.ts
@@ -60,6 +60,11 @@ namespace pixi_display {
                 }
             }
 
+            if (db) {
+                db[0].framebuffer.multisample = rt.framebuffer.multisample;
+                db[1].framebuffer.multisample = rt.framebuffer.multisample;
+            }
+
             this._tempRenderTarget = renderer.renderTexture.current;
             this._tempRenderTargetSource.copyFrom(renderer.renderTexture.sourceFrame);
 
@@ -99,6 +104,7 @@ namespace pixi_display {
 
         popTexture(renderer: PIXI.Renderer) {
             renderer.batch.flush();
+            renderer.framebuffer.blit();
             // switch filters back
             const filterStack = renderer.filter.defaultFilterStack;
             if (filterStack.length > 1) {


### PR DESCRIPTION
This change makes it possible to enable multisampling; it works with and without double buffering.

```js
const layer = new PIXI.display.Layer();
layer.useRenderTexture = true;
layer.useDoubleBuffer = true;

const renderTexture = layer.getRenderTexture();
renderTexture.framebuffer.multisample = PIXI.MSAA_QUALITY.HIGH;

const layerSprite = new PIXI.Sprite(renderTexture);

// ...
```