### PR TITLE
Changed method call in applyParticleMixin

### DIFF
--- a/src/DisplayMixin.ts
+++ b/src/DisplayMixin.ts
@@ -115,5 +115,5 @@ export function applyContainerRenderMixin(CustomRenderContainer: any): void
 export function applyParticleMixin(ParticleContainer: any): void
 {
     ParticleContainer.prototype.layerableChildren = false;
-    this.applyRenderMixing(ParticleContainer);
+    applyContainerRenderMixin(ParticleContainer);
 }


### PR DESCRIPTION
Calling `applyParticleMixin(ParticleContainer)` throws an error, because it calls `this.applyRenderMixing` instead of `applyContainerRenderMixin `. Changed to `applyContainerRenderMixin`.